### PR TITLE
Api provides functionality for selecting genres filter

### DIFF
--- a/app/controllers/api/v1/movie_person_controller.rb
+++ b/app/controllers/api/v1/movie_person_controller.rb
@@ -1,5 +1,6 @@
 require 'date'
 class Api::V1::MoviePersonController < ApplicationController
+  include GenreTranslator
   def show
     begin
       api_key = Rails.application.credentials.movie_db[:api_key]
@@ -17,6 +18,8 @@ class Api::V1::MoviePersonController < ApplicationController
   def serialize_person(data)
     cast = data['cast'] || []
     crew = data['crew'] || []
+    genre = id_to_name(18)
+    binding.pry
     upcoming_cast = cast.select {|movie| movie['release_date'].to_s > Date.today.prev_month(3).to_s }
     upcoming_crew = crew.select {|movie| (movie['release_date'].to_s > Date.today.prev_month(3).to_s) && (movie['job'] === 'Director') }
     upcoming = upcoming_cast.concat(upcoming_crew)

--- a/app/controllers/api/v1/movie_person_controller.rb
+++ b/app/controllers/api/v1/movie_person_controller.rb
@@ -18,20 +18,24 @@ class Api::V1::MoviePersonController < ApplicationController
   def serialize_person(data)
     cast = data['cast'] || []
     crew = data['crew'] || []
-    genre = id_to_name(18)
-    binding.pry
     upcoming_cast = cast.select {|movie| movie['release_date'].to_s > Date.today.prev_month(3).to_s }
     upcoming_crew = crew.select {|movie| (movie['release_date'].to_s > Date.today.prev_month(3).to_s) && (movie['job'] === 'Director') }
     upcoming = upcoming_cast.concat(upcoming_crew)
     upcoming.map!{ |movie|
+      genres = movie['genre_ids'].map{|genre| GenreTranslator.id_to_name(genre)}
       {
         title: movie['title'],
         role: movie['character'] ? "Actor(#{movie['character']})" : 'Director',
         release_date: movie['release_date'],
         description: movie['overview'],
-        image: "https://image.tmdb.org/t/p/w154#{movie['poster_path']}"
+        image: "https://image.tmdb.org/t/p/w154#{movie['poster_path']}",
+        genres: genres
       }
     }
+    
+    if (params.has_key?('genres') && upcoming.length != 0)
+      upcoming.select! {|movie| (movie[:genres] & params[:genres]).length != 0 }
+    end
     { status: upcoming.length == 0 ? :no_content : :ok, data: { id: data['id'], movies: upcoming }}
   end
 end

--- a/app/controllers/concerns/genre_translator.rb
+++ b/app/controllers/concerns/genre_translator.rb
@@ -1,14 +1,14 @@
 require 'json'
 module GenreTranslator
   def self.id_to_name(id)
-    file = File.open('/lib/cached/genre_ids.json')
+    file = File.read(File.join Rails.root, 'lib', 'cached', 'genre_ids.json')
     data = JSON.parse(file)
-    data.find {|genre| genre.id == id }['name']
+    data.find {|genre| genre['id'] == id }['name']
   end
 
   def self.name_to_id(name)
-    file = File.open('/lib/cached/genre_ids.json')
+    file = File.read(File.join Rails.root, 'lib', 'cached', 'genre_ids.json')
     data = JSON.parse(file) 
-    data.find {|genre| genre.name == name }['id']
+    data.find {|genre| genre['name'] == name }['id']
   end
 end

--- a/app/controllers/concerns/genre_translator.rb
+++ b/app/controllers/concerns/genre_translator.rb
@@ -1,0 +1,14 @@
+require 'json'
+module GenreTranslator
+  def self.id_to_name(id)
+    file = File.open('/lib/cached/genre_ids.json')
+    data = JSON.parse(file)
+    data.find {|genre| genre.id == id }['name']
+  end
+
+  def self.name_to_id(name)
+    file = File.open('/lib/cached/genre_ids.json')
+    data = JSON.parse(file) 
+    data.find {|genre| genre.name == name }['id']
+  end
+end

--- a/lib/cached/genre_ids.json
+++ b/lib/cached/genre_ids.json
@@ -1,0 +1,80 @@
+{
+  "genres": [
+    {
+      "id": 28,
+      "name": "Action"
+    },
+    {
+      "id": 12,
+      "name": "Adventure"
+    },
+    {
+      "id": 16,
+      "name": "Animation"
+    },
+    {
+      "id": 35,
+      "name": "Comedy"
+    },
+    {
+      "id": 80,
+      "name": "Crime"
+    },
+    {
+      "id": 99,
+      "name": "Documentary"
+    },
+    {
+      "id": 18,
+      "name": "Drama"
+    },
+    {
+      "id": 10751,
+      "name": "Family"
+    },
+    {
+      "id": 14,
+      "name": "Fantasy"
+    },
+    {
+      "id": 36,
+      "name": "History"
+    },
+    {
+      "id": 27,
+      "name": "Horror"
+    },
+    {
+      "id": 10402,
+      "name": "Music"
+    },
+    {
+      "id": 9648,
+      "name": "Mystery"
+    },
+    {
+      "id": 10749,
+      "name": "Romance"
+    },
+    {
+      "id": 878,
+      "name": "Science Fiction"
+    },
+    {
+      "id": 10770,
+      "name": "TV Movie"
+    },
+    {
+      "id": 53,
+      "name": "Thriller"
+    },
+    {
+      "id": 10752,
+      "name": "War"
+    },
+    {
+      "id": 37,
+      "name": "Western"
+    }
+  ]
+}

--- a/lib/cached/genre_ids.json
+++ b/lib/cached/genre_ids.json
@@ -1,80 +1,78 @@
-{
-  "genres": [
-    {
-      "id": 28,
-      "name": "Action"
-    },
-    {
-      "id": 12,
-      "name": "Adventure"
-    },
-    {
-      "id": 16,
-      "name": "Animation"
-    },
-    {
-      "id": 35,
-      "name": "Comedy"
-    },
-    {
-      "id": 80,
-      "name": "Crime"
-    },
-    {
-      "id": 99,
-      "name": "Documentary"
-    },
-    {
-      "id": 18,
-      "name": "Drama"
-    },
-    {
-      "id": 10751,
-      "name": "Family"
-    },
-    {
-      "id": 14,
-      "name": "Fantasy"
-    },
-    {
-      "id": 36,
-      "name": "History"
-    },
-    {
-      "id": 27,
-      "name": "Horror"
-    },
-    {
-      "id": 10402,
-      "name": "Music"
-    },
-    {
-      "id": 9648,
-      "name": "Mystery"
-    },
-    {
-      "id": 10749,
-      "name": "Romance"
-    },
-    {
-      "id": 878,
-      "name": "Science Fiction"
-    },
-    {
-      "id": 10770,
-      "name": "TV Movie"
-    },
-    {
-      "id": 53,
-      "name": "Thriller"
-    },
-    {
-      "id": 10752,
-      "name": "War"
-    },
-    {
-      "id": 37,
-      "name": "Western"
-    }
-  ]
-}
+[
+  {
+    "id": 28,
+    "name": "Action"
+  },
+  {
+    "id": 12,
+    "name": "Adventure"
+  },
+  {
+    "id": 16,
+    "name": "Animation"
+  },
+  {
+    "id": 35,
+    "name": "Comedy"
+  },
+  {
+    "id": 80,
+    "name": "Crime"
+  },
+  {
+    "id": 99,
+    "name": "Documentary"
+  },
+  {
+    "id": 18,
+    "name": "Drama"
+  },
+  {
+    "id": 10751,
+    "name": "Family"
+  },
+  {
+    "id": 14,
+    "name": "Fantasy"
+  },
+  {
+    "id": 36,
+    "name": "History"
+  },
+  {
+    "id": 27,
+    "name": "Horror"
+  },
+  {
+    "id": 10402,
+    "name": "Music"
+  },
+  {
+    "id": 9648,
+    "name": "Mystery"
+  },
+  {
+    "id": 10749,
+    "name": "Romance"
+  },
+  {
+    "id": 878,
+    "name": "Science Fiction"
+  },
+  {
+    "id": 10770,
+    "name": "TV Movie"
+  },
+  {
+    "id": 53,
+    "name": "Thriller"
+  },
+  {
+    "id": 10752,
+    "name": "War"
+  },
+  {
+    "id": 37,
+    "name": "Western"
+  }
+]

--- a/spec/requests/v1/movie_person_request_spec.rb
+++ b/spec/requests/v1/movie_person_request_spec.rb
@@ -51,16 +51,17 @@ RSpec.describe "MoviePeople", type: :request do
 
   describe 'GET/api/v1/movie_person/ genre params' do
     before do
-      get '/api/v1/movie_person/31', {genres: ["War", "Music"]}
+      @genres = ["War", "Music"]
+      get '/api/v1/movie_person/31', params: {genres: @genres}
     end
   
     it 'returns only movies that has these genres' do
       expect(response_json['movies'].length).to eq 3
     end
 
-    it 'each returned movies has atleast on of the genres' do
+    it 'each returned movies has atleast one of the genres' do
       response_json['movies'].each do |movie|
-        expect(movie['genres']).to eq "War"
+        expect(movie['genres'] & @genres).not_to eq []
       end
     end
   end

--- a/spec/requests/v1/movie_person_request_spec.rb
+++ b/spec/requests/v1/movie_person_request_spec.rb
@@ -48,4 +48,20 @@ RSpec.describe "MoviePeople", type: :request do
       expect(response).to have_http_status 204
     end
   end
+
+  describe 'GET/api/v1/movie_person/ genre params' do
+    before do
+      get '/api/v1/movie_person/31', {genres: ["War", "Music"]}
+    end
+  
+    it 'returns only movies that has these genres' do
+      expect(response_json['movies'].length).to eq 3
+    end
+
+    it 'each returned movies has atleast on of the genres' do
+      response_json['movies'].each do |movie|
+        expect(movie['genres']).to eq "War"
+      end
+    end
+  end
 end


### PR DESCRIPTION
[PT card](https://www.pivotaltracker.com/story/show/172793085)
### In this PR
The /api/v1/movie_person endpoint has been upgraded to also take the param genres: ["Action"].
If params is provided, then it will filter, if it is not, then no filtering will take place.   

Valid genres are: "Action", "Adventure", "Animation", "Comedy", "Crime", "Documentary", "Drama", "Family", "Fantasy", "History", "Horror", "Music", "Mystery", "Romance", "Science Fiction", "TV Movie", "Thriller", "War", "Western".
Invalid genres will not break the request. If genres is not an array, that might happen.
